### PR TITLE
Extra spec-cases, to support formatting ALL UPPERCASE input

### DIFF
--- a/spec/examples.yaml
+++ b/spec/examples.yaml
@@ -43,3 +43,13 @@ should_pass:
     expect:  | This Is a test.com!?
   - example: | 
     expect:  | 
+  - example: | Dr. Strangelove (or: how I Learned to Stop Worrying and Love the Bomb)
+    expect:  | Dr. Strangelove (Or: How I Learned to Stop Worrying and Love the Bomb)
+  - example: "   this is trimming"
+    expect:  | This Is Trimming
+  - example: "this is trimming  "
+    expect:  | This Is Trimming
+  - example: "   this is trimming  "
+    expect:  | This Is Trimming
+  - example: | IF IT’S ALL CAPS, FIX IT
+    expect:  | If It’s All Caps, Fix It


### PR DESCRIPTION
With this addition, the specfailures become:

<pre>
1)
'String should be the expected value (Dr. Strangelove (Or: How I Learned to Stop Worrying and Love the Bomb))' FAILED
expected: "Dr. Strangelove (Or: How I Learned to Stop Worrying and Love the Bomb)",
     got: "Dr. Strangelove (or: How I Learned to Stop Worrying and Love the Bomb)" (using ==)
./spec/titlecase_spec.rb:9:

2)
'String should be the expected value (If It’s All Caps, Fix It)' FAILED
expected: "If It’s All Caps, Fix It",
     got: "If IT’S ALL CAPS, FIX IT" (using ==)
./spec/titlecase_spec.rb:9:
</pre>
